### PR TITLE
Adapt script to manage pip-installed supervisor

### DIFF
--- a/debian-pip
+++ b/debian-pip
@@ -19,11 +19,11 @@
 # Do NOT "set -e"
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin
 DESC="Run a set of applications as daemons."
 NAME=supervisord
-DAEMON=/usr/bin/$NAME   # Supervisord is installed in /usr/bin by default, but /usr/sbin would make more sense.
-SUPERVISORCTL=/usr/bin/supervisorctl
+DAEMON=/usr/local/bin/$NAME   # Compatible with pip install
+SUPERVISORCTL=/usr/local/bin/supervisorctl
 PIDFILE=/var/run/$NAME.pid
 DAEMON_ARGS="--pidfile ${PIDFILE}"
 SCRIPTNAME=/etc/init.d/$NAME
@@ -41,6 +41,53 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . /lib/lsb/init-functions
 
+CONFIG_OPTS="-c /etc/supervisor/supervisord.conf"
+DAEMON_OPTS="$CONFIG_OPTS -j $PIDFILE $DAEMON_OPTS"
+
+running_pid()
+{
+    # Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] &&  return 1
+    (cat /proc/$pid/cmdline | tr "\000" "\n"|grep -q $name) || return 1
+    return 0
+}
+
+running()
+{
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    # Obtain the pid and check it against the binary name
+    pid=`cat $PIDFILE`
+    running_pid $pid $DAEMON || return 1
+    return 0
+}
+
+force_stop() {
+# Forcefully kill the process
+    [ ! -f "$PIDFILE" ] && return
+    if running ; then
+        kill -15 $pid
+        # Is it really dead?
+        [ -n "$DODTIME" ] && sleep "$DODTIME"s
+        if running ; then
+            kill -9 $pid
+            [ -n "$DODTIME" ] && sleep "$DODTIME"s
+            if running ; then
+                echo "Cannot kill $NAME (pid=$pid)!"
+                exit 1
+            fi
+        fi
+    fi
+    rm -f $PIDFILE
+    return 0
+}
+
 #
 # Function that starts the daemon/service
 #
@@ -53,7 +100,7 @@ do_start()
         [ -e $PIDFILE ] && return 1
 
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
-		$DAEMON_ARGS \
+		$DAEMON_OPTS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
 	# to handle requests from services started subsequently which depend
@@ -73,7 +120,7 @@ do_stop()
         [ -e $PIDFILE ] || return 1
 
 	# Stop all processes under supervisord control.
-	$SUPERVISORCTL stop all
+	$SUPERVISORCTL $CONFIG_OPTS stop all
 
 	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
 	RETVAL="$?"
@@ -121,6 +168,16 @@ case "$1" in
 		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
 	esac
 	;;
+  force-stop)
+        echo -n "Forcefully stopping $NAME: "
+        force_stop
+        if ! running ; then
+            echo "$DESC."
+        else
+            echo " ERROR."
+        fi
+        ;;
+ 
   #reload|force-reload)
 	#
 	# If do_reload() is not implemented then leave this commented out
@@ -152,9 +209,19 @@ case "$1" in
 		;;
 	esac
 	;;
+  status)
+	echo -n "$NAME is "
+	if running ;  then
+        	echo "running"
+	else
+        	echo " not running."
+        	exit 1
+	fi
+	$SUPERVISORCTL $CONFIG_OPTS status
+	;;
   *)
 	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|force-stop|restart|force-reload|status}" >&2
 	exit 3
 	;;
 esac


### PR DESCRIPTION
On debian, the default package is really outdated, while the pip version is up to date. The paths aren't right and the package maintainer's init script aren't working. This provides a working version.

Inspired by the ubuntu script in this repository.
